### PR TITLE
GH Action write permissions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,5 +1,8 @@
 name: github pages
 
+permissions:
+  contents: write
+
 on:
   push:
     branches:

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-personal.mathgradboard.com


### PR DESCRIPTION
At least for me the default behaviour of the github action token was
readonly permissions resulting in a failed build. You can change the
default behaviour in the UI but this makes it one less thing to worry
about.