### PR TITLE
config.toml document socials

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,9 +1,7 @@
-theme = "hugo-resume"
 languageCode = "en-us"
 
 title = "Pythagoras of Samos"
 baseURL = "https://personal.mathgradboard.com/"
-
 
 [params]
 address = "Metapontum Village, Italy"
@@ -39,14 +37,15 @@ name = "GitHub"
 # No need to change anything below here
 # ==============================================================================
 
+
+theme = "hugo-resume"
+PygmentsCodeFences = true
+PygmentsCodeFencesGuessSyntax = true
+PygmentsStyle = "monokai"
+enableGitInfo = false
+
 [outputs]
 home = ["HTML", "JSON"]
 
 [taxonomies]
 tag = "tags"
-
-
-PygmentsCodeFences = true
-PygmentsCodeFencesGuessSyntax = true
-PygmentsStyle = "monokai"
-enableGitInfo = false

--- a/config.toml
+++ b/config.toml
@@ -32,6 +32,15 @@ name = "LinkedIn"
 link = "https://github.com/uiowa-mgb"
 name = "GitHub"
 
+# Add as many as you like. So long as the name is found on this list
+# https://fontawesome.com/v4/icons/#brand
+# it should render a logo. For example:
+
+# [[params.handles]]
+# link = "https://mathoverflow.net/users/"
+# name = "Stack-Overflow"
+
+# This would render a stack-overflow icon linking to your page if you wanted
 
 # ==============================================================================
 # No need to change anything below here


### PR DESCRIPTION
Made two minor tweaks to the `config.toml` file.

First: moved the theme below the don't change line. Changing the theme is not a trivial thing to do (I don't think) so I think it makes sense to chuck that down there.

Second: added another example of the socials and a link to a complete list of which socials are accepted.